### PR TITLE
Bionics, Armor, Profession, Spelling updates

### DIFF
--- a/Touhou/TOUHOU_TODO.txt
+++ b/Touhou/TOUHOU_TODO.txt
@@ -22,8 +22,6 @@ Acceptable stats for any clothing or weaponry added by this mod (Lots of copy/pa
 
 "Balancing"/"Fun" (Some professions might feel too identical or just not fun to play, etc)
 
-Burst-fire Finger Laser CBM for Reisen (Can only fire in semi-auto even with BURST_ONLY)
-
 Seiga's hairstick cutting through walls
 
 ---------

--- a/Touhou/touhou_armor.json
+++ b/Touhou/touhou_armor.json
@@ -23,7 +23,7 @@
     "type": "ARMOR",
     "name": "celestial dress",
     "name_plural": "celestial dress",
-    "description": "A blue dress with a cloud pattern on the skirt and a white apron. The apron has a rainbow-patterned shard link on it.",
+    "description": "A blue dress with a cloud pattern on the skirt and a white apron. The apron has a rainbow-patterned shard link on it, and a small pocket for holding items.",
     "weight": 680,
     "volume": 14,
     "price": 18000,
@@ -34,6 +34,7 @@
     "covers": [ "LEGS", "TORSO" ],
     "coverage": 85,
     "encumbrance": 7,
+	"storage": 1,
     "warmth": 15,
     "material_thickness": 2,
     "flags": [ "VARSIZE", "FANCY" ]

--- a/Touhou/touhou_bio.json
+++ b/Touhou/touhou_bio.json
@@ -15,9 +15,9 @@
     "pierce": 15,
     "dispersion": 10,
     "durability": 10,
-	"burst": 5,
     "reload": 0,
+	"modes": [ [ "DEFAULT", "auto", 5 ] ],
     "ammo_effects": [ "LASER" ],
-    "flags": [  "BURST_ONLY", "NEVER_JAMS", "TRADER_AVOID" ]
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID" ]
   }
 ]

--- a/Touhou/touhou_classes.json
+++ b/Touhou/touhou_classes.json
@@ -36,18 +36,19 @@
             "PROF_REISEN"
         ],
         "items": {
-            "both": [
-				"leather_pouch",
+            "both": {
+                "items": [
 				"dress_shirt",
 				"tie_reisen",
 				"suit_reisen",
 				"stockings",
 				"skirt",
-				"sneakers",
-				"lunar_rifle",
-				"shoulder_strap",
-				"knit_scarf"
-            ],
+				"sneakers"
+                ],
+                "entries": [
+                    { "item": "lunar_rifle", "container-item": "shoulder_strap" }
+                ]
+            },
             "male": [
                 "boxer_shorts"
             ],
@@ -89,22 +90,26 @@
             }
         ],
         "items": {
-            "both": [
-				"runner_bag",
+            "both": {
+                "items": [
+                "leather_pouch",
 				"stockings",
 				"maid_dress",
 				"maid_hat",
-				"knife_combat",
-				"sheath",
 				"throwing_knife",
 				"throwing_knife",
 				"throwing_knife",
 				"throwing_knife",
 				"throwing_knife",
 				"throwing_knife",
+				"pocketwatch",
 				"sneakers",
 				"knit_scarf"
-            ],
+                ],
+                "entries": [
+                    { "item": "knife_combat", "container-item": "sheath" }
+                ]
+            },
             "male": [
                 "boxer_shorts"
             ],
@@ -208,22 +213,24 @@
             }
         ],
 		"traits": [
-			"PROF_REISENTAIL",
+            "PROF_REISENTAIL",
             "PROF_REISEN"
         ],
         "items": {
-            "both": [
-				"rucksack",
+            "both": {
+                "items": [
 				"dress_shirt",
 				"tie_reisen",
 				"suit_reisen",
 				"stockings",
 				"skirt",
 				"sneakers",
-				"lunatic_pistol",
-				"holster_reisen",
 				"knit_scarf"
-            ],
+                ],
+                "entries": [
+                    { "item": "lunatic_pistol", "container-item": "holster_reisen" }
+                ]
+            },
             "male": [
                 "boxer_shorts"
             ],
@@ -231,8 +238,7 @@
                 "bra",
                 "panties"
             ]
-        },
-        "flags" : ["SCEN_ONLY"]
+        }
     },
 	{
         "type": "profession",
@@ -270,6 +276,7 @@
         "items": {
             "both": [
 				"stockings",
+				"runner_bag",
 				"dress_seiga",
 				"hairstick_seiga",
 				"sneakers",
@@ -287,11 +294,10 @@
         },
         "flags" : ["SCEN_ONLY"]
     },
-	
 	{
         "type": "profession",
-        "ident": "youmou_konpaku",
-        "name": "Youmou Konpaku",
+        "ident": "youmu_konpaku",
+        "name": "Youmu Konpaku",
         "description": "You were the faithful half-human, half-phantom servant of Yuyuko Saigyouji until the cataclysm struck, separating both of you. You stand alone against the coming darkness, but at least you have your skills as an expert swordswoman!",
         "points": 0,
 		"CBMs":[
@@ -315,21 +321,22 @@
             }
         ],
 		"traits": [
-            "PROF_YOMOU",
-			"YOMOU_PHANTOM"
+            "PROF_YOUMU",
+			"YOUMU_PHANTOM"
         ],
         "items": {
-            "both": [
-                "katana",
-                "scabbard",
-				"scabbard",
-				"stockings",
+            "both": {
+                "items": [
+                "stockings",
 				"dress_youmou",
 				"ribbon_youmou",
-				"sneakers",
-				"knit_scarf",
-                "wakizashi"
-            ],
+				"sneakers"
+                ],
+                "entries": [
+                    { "item": "katana", "container-item": "scabbard" },
+					{ "item": "wakizashi", "container-item": "scabbard" }
+                ]
+            },
             "male": [
                 "boxer_shorts"
             ],
@@ -337,7 +344,6 @@
                 "bra",
                 "panties"
             ]
-        },
-        "flags" : ["SCEN_ONLY"]
+        }
     }
 ]

--- a/Touhou/touhou_mutations.json
+++ b/Touhou/touhou_mutations.json
@@ -19,7 +19,7 @@
     },
 	{
         "type" : "mutation",
-        "id" : "YOMOU_PHANTOM",
+        "id" : "YOUMU_PHANTOM",
         "name" : "Phantom Half",
         "points" : 0,
 		"visibility": 10,
@@ -30,7 +30,7 @@
         "profession": true
     },{
         "type" : "mutation",
-        "id" : "PROF_YOMOU",
+        "id" : "PROF_YOUMU",
         "name" : "Swordswoman",
         "points" : 0,
         "description" : "You are experienced in the usage of swords.",

--- a/Touhou/touhou_scenarios.json
+++ b/Touhou/touhou_scenarios.json
@@ -7,7 +7,7 @@
     "description": "No limits on where to start. All Touhou professions.",
     "allowed_locs": ["fema_entrance_s","fema_s", "mansion_entrance_s","mansion_s","shelter", "boarded_house", "field", "house", "s_grocery", "s_gun", "s_garage", "pawn", "bank", "mil_surplus", "furniture", "s_library", "s_bookstore", "cabin", "hospital", "lmoe", "forest", "lab_stairs", "lab_finale", "ice_lab_stairs",
 	"ice_lab_finale", "mall_a_12", "mall_a_30", "fire_station", "police", "school", "mine_finale", "prison", "strange_grove", "island_temple", "impact_site", "curious_structure"],
-      "professions" : ["sakuya_izayoi", "reisen_udongein_inaba", "tenshi_hinanawi", "seiga_kaku", "reisen_II", "youmou_konpaku"],
+      "professions" : ["sakuya_izayoi", "reisen_udongein_inaba", "tenshi_hinanawi", "seiga_kaku", "reisen_II", "youmu_konpaku"],
 	  "start_name" : "Anywhere"
   }
 ]

--- a/Touhou/touhou_ups.json
+++ b/Touhou/touhou_ups.json
@@ -45,7 +45,7 @@
     "dispersion": 20,
     "durability": 8,
 	"burst": 3,
-    "ups_charges": 6,
+    "ups_charges": 5,
     "reload": 0,
     "valid_mod_locations": [ [ "accessories", 2 ], [ "grip", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],


### PR DESCRIPTION
Tenshi's dress gets some storage to hold the Sword of Hisou
Reisen's Finger Gun CBM fires five lasers
Reisen/Rei'sen/Sakuya/Youmu start with their weapons already holstered
Sakuya gets Leather Pouch, Seiga gets Runner Bag. Switched the two between them.
Rei'sen Leather Pouch removed since she starts with a holstered rifle
Youmu isn't misspelled anymore (oops)
Reisen's Lunatic Pistol uses 5 UPS charges instead of 6 now